### PR TITLE
Add support for Debian 9 (stretch)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
   - name: Debian
     versions:
     - jessie
+    - stretch
   - name: EL
     versions:
     - 7

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -1,16 +1,24 @@
 - name: Include distribution specific variables.
   include_vars: "distribution_{{ ansible_distribution }}.yml"
 
+- name: Include distribution version specific variables when available.
+  include_vars:
+    dir: 'vars'
+    files_matching: "{{ item }}"
+    depth: 1
+  with_items:
+    - "distribution_{{ ansible_distribution }}{{ ansible_lsb.major_release }}.yml"
+
 - block:
 
   - name: Install libssl dependency.
     package:
-      name: libssl1.0.0
+      name: "libssl{{ aem_dispatcher_libssl_version }}"
       state: present
 
   - name: Create compatibility links.
     file:
-      src: "{{ aem_dispatcher_libssl_path }}/{{ item }}.1.0.0"
+      src: "{{ aem_dispatcher_libssl_path }}/{{ item }}.{{ aem_dispatcher_libssl_version }}"
       dest: "{{ aem_dispatcher_libssl_path }}/{{ item }}.10"
       state: link
     with_items:

--- a/vars/distribution_Debian.yml
+++ b/vars/distribution_Debian.yml
@@ -1,1 +1,2 @@
 aem_dispatcher_libssl_path: /usr/lib/x86_64-linux-gnu
+aem_dispatcher_libssl_version: "1.0.0"

--- a/vars/distribution_Debian9.yml
+++ b/vars/distribution_Debian9.yml
@@ -1,0 +1,1 @@
+aem_dispatcher_libssl_version: "1.0.2"


### PR DESCRIPTION
On Debian 9 we have to use libssl1.0.2. libssl1.0.0 is not available anymore.