### PR TITLE
Add support for custom httpd ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ The dispatcher version to install.
 
 Whether to install the Dispatcher version which supports SSL for communication with the render instance.
 
+    aem_dispatcher_port: 80
+
+The http port the webserver is listening on
+
+    aem_dispatcher_port_ssl: 443
+
+The https port the webserver is listening on
+
 	dispatcher_download_path: /tmp
 
 Path to download the Dispatcher tarball to.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,12 @@
 aem_dispatcher_version: 4.2.2
 # Whether to install dispatcher with SSL support
 aem_dispatcher_ssl_support: true
+
+# http dispatcher port
+aem_dispatcher_port: 80
+# https dispatcher port
+aem_dispatcher_port_ssl: 443
+
 # Path to download the dispatcher tarball to
 aem_dispatcher_download_path: /tmp
 # Build automatically from target environment and aem_dispatcher_version if not specified

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,5 +30,7 @@ dependencies:
   - {
       role: geerlingguy.apache,
       apache_remove_default_vhost: true,
-      apache_create_vhosts: false
+      apache_create_vhosts: false,
+      apache_listen_port: "{{ aem_dispatcher_port }}",
+      apache_listen_port_ssl: "{{ aem_dispatcher_port_ssl }}"
     }


### PR DESCRIPTION
This PR depends on:
* https://github.com/wcm-io-devops/conga-aem-plugin/pull/2
* https://github.com/wcm-io-devops/conga-aem-definitions/pull/32

and adds support for custom http and https ports.