### PR TITLE
Remove default vhost removal, since this is now implemented with https://github.com/wcm-io-devops/ansible-role-apache/pull/3

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,7 @@ dependencies:
   - {
       role: geerlingguy.apache,
       apache_remove_default_vhost: true,
+      apache_remove_default_vhost_ssl: true,
       apache_create_vhosts: false,
       apache_listen_port: "{{ aem_dispatcher_port }}",
       apache_listen_port_ssl: "{{ aem_dispatcher_port_ssl }}"

--- a/tasks/setup_RedHat.yml
+++ b/tasks/setup_RedHat.yml
@@ -1,16 +1,3 @@
-# This should be done by the apache role as well
-# Remove once https://github.com/geerlingguy/ansible-role-apache/issues/81 is resolved
-- name: Remove default vhosts.
-  file:
-    path: "{{ apache_conf_path }}/vhosts.conf"
-    state: absent
-  with_items:
-    - vhosts.conf
-    - userdir.conf
-    - welcome.conf
-  notify: restart apache
-  when: apache_remove_default_vhost
-
 - name: Enable dispatcher module.
   copy:
     dest: "{{ apache_server_root }}/conf.modules.d/01-dispatcher.conf"


### PR DESCRIPTION
This PR depends on: https://github.com/wcm-io-devops/ansible-role-apache/pull/3.
When this PR is accepted there is no need anymore to remove default vhosts within the aem-dispatcher role.