### PR TITLE
Add wcm-io-devops role prefix, switched apache dependency to wcm-io-devops fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# aem-dispatcher
+# wcm-io-devops.aem-dispatcher
 
 This role installs the [AEM Dispatcher](https://helpx.adobe.com/experience-manager/dispatcher/using/dispatcher.html) Apache module on Debian/Ubuntu or RHEL/CentOS servers. It will also ensure that Apache itself is installed (by depending on the [geerlingguy.apache](https://galaxy.ansible.com/geerlingguy/apache/) role).
 > This role was developed as part of the wcm.io set of roles to integrate Ansible with [CONGA](http://devops.wcm.io/conga/) but can be used independently of it.
@@ -71,7 +71,7 @@ Maven coordinates for retrieving the installation file from Nexus. Version and c
 
 ## Dependencies
 
-This role depends on the [geerlingguy.apache](https://galaxy.ansible.com/geerlingguy/apache/) role for installing Apache.
+This role depends on the [wcm-io-devops.apache](https://github.com/wcm-io-devops/ansible-role-apache) role for installing Apache.
 
 ## Example Playbook
 
@@ -79,7 +79,7 @@ Installs AEM in `/opt/adobe/aem-author`:
 
     - hosts: webserver
       roles:
-         - { role: aem-dispatcher, aem_dispatcher_version: 4.2.3 }
+         - { role: wcm-io-devops.aem-dispatcher, aem_dispatcher_version: 4.2.3 }
 
 ## License
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,7 @@ galaxy_info:
 
 dependencies:
   - {
-      role: geerlingguy.apache,
+      role: wcm-io-devops.apache,
       apache_remove_default_vhost: true,
       apache_remove_default_vhost_ssl: true,
       apache_create_vhosts: false,


### PR DESCRIPTION
This PR depends on the following PRs:

* https://github.com/wcm-io-devops/ansible-aem-cms/pull/7
* https://github.com/wcm-io-devops/ansible-conga-aem-dispatcher/pull/3
* https://github.com/wcm-io-devops/ansible-conga-files/pull/1
* https://github.com/wcm-io-devops/ansible-conga-facts/pull/5
* https://github.com/wcm-io-devops/ansible-conga-maven/pull/2
* https://github.com/wcm-io-devops/ansible-aem-service/pull/3
* https://github.com/wcm-io-devops/ansible-conga-aem-packages/pull/13
* https://github.com/wcm-io-devops/ansible-aem-dispatcher-flush/pull/3
* https://github.com/wcm-io-devops/ansible-conga-aem-cms/pull/4
* https://github.com/wcm-io-devops/ansible-conga-bundle-files/pull/4
* https://github.com/wcm-io-devops/ansible-aem-security/pull/1
* https://github.com/wcm-io-devops/ansible-conga-aem-dispatcher-flush/pull/2
* https://github.com/wcm-io-devops/ansible-conga-aem-smoke-test/pull/2
* https://github.com/wcm-io-devops/ansible-conga-aem-dispatcher-smoke-test/pull/6
* https://github.com/wcm-io-devops/ansible-role-apache/pull/4