### PR TITLE
Add Debian 10 support; remove Debian 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This role requires Ansible 2.4 or higher and works with Dispatcher 4.2.x or high
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-	aem_dispatcher_version: 4.3.2
+	aem_dispatcher_version: 4.3.3
 	
 The dispatcher version to install.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,8 +15,8 @@ galaxy_info:
     - bionic
   - name: Debian
     versions:
-    - jessie
     - stretch
+    - buster
   - name: EL
     versions:
     - 7

--- a/vars/distribution_Debian-10.yml
+++ b/vars/distribution_Debian-10.yml
@@ -1,1 +1,0 @@
-aem_dispatcher_libssl_version: "1.1"

--- a/vars/distribution_Debian-10.yml
+++ b/vars/distribution_Debian-10.yml
@@ -1,0 +1,1 @@
+aem_dispatcher_libssl_version: "1.1"

--- a/vars/distribution_Debian-9.yml
+++ b/vars/distribution_Debian-9.yml
@@ -1,1 +1,0 @@
-aem_dispatcher_libssl_version: "1.0.2"

--- a/vars/distribution_Debian.yml
+++ b/vars/distribution_Debian.yml
@@ -1,2 +1,1 @@
 aem_dispatcher_libssl_path: /usr/lib/x86_64-linux-gnu
-aem_dispatcher_libssl_version: "1.0.0"

--- a/vars/distribution_Ubuntu.yml
+++ b/vars/distribution_Ubuntu.yml
@@ -1,2 +1,1 @@
-aem_dispatcher_libssl_version: "1.0.0"
 aem_dispatcher_libssl_path: /lib/x86_64-linux-gnu

--- a/vars/family_Debian.yml
+++ b/vars/family_Debian.yml
@@ -1,2 +1,5 @@
 aem_dispatcher_module_path: /usr/lib/apache2/modules
 _aem_dispatcher_apache_server_root: "{{ aem_dispatcher_apache_server_root | default(apache_server_root) | default('/etc/apache2') }}"
+
+aem_dispatcher_libssl_version: >-
+  {{ '1.1' if ansible_distribution_major_version is version('10', '>=') else '1.0.2' }}


### PR DESCRIPTION
Also, because we need `aem_dispatcher_libssl_version` already in `tarball_name.yml`, I moved its declaration to `family_Debian.yml`, analogous to how we do at `family_RedHat.yml`. Distribution version specific variable files that did not contain anything but this variable were removed.