### PR TITLE
Add support for Ubuntu 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
           - NAME: min_ansible_version
             ANSIBLE_VERSION: "==2.7.*"
             ANSIBLE_LINT_VERSION: "==4.2.*"
-          - NAME: latest
-            ANSIBLE_VERSION: ""
-            ANSIBLE_LINT_VERSION: ""
 
     steps:
       - name: Check out the codebase.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   company: pro!vision
   issue_tracker_url: https://wcm-io.atlassian.net
   license: Apache
-  min_ansible_version: 2.7
+  min_ansible_version: "2.7"
 
   platforms:
     - name: Ubuntu

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -12,10 +12,17 @@
 
 - block:
 
-    - name: Install libssl dependency.
+    - name: Install libssl dependency via package manager.
       package:
         name: "libssl{{ aem_dispatcher_libssl_version }}"
         state: present
+      when: aem_dispatcher_libssl_deb_package is not defined
+
+    - name: Install libssl dependency via deb package.
+      ansible.builtin.apt:
+        deb: "{{ aem_dispatcher_libssl_deb_package }}"
+        state: present
+      when: aem_dispatcher_libssl_deb_package is defined
 
     - name: Create compatibility links.
       file:

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -19,7 +19,7 @@
       when: aem_dispatcher_libssl_deb_package is not defined
 
     - name: Install libssl dependency via deb package.
-      ansible.builtin.apt:
+      apt:
         deb: "{{ aem_dispatcher_libssl_deb_package }}"
         state: present
       when: aem_dispatcher_libssl_deb_package is defined

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,5 @@
 ---
 - name: wcm_io_devops.apache
-  version: 3.1.4-1
+  src: https://github.com/wcm-io-devops/ansible-role-apache.git
+  version: master
+  scm: git

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,2 +1,3 @@
 ---
 - name: wcm_io_devops.apache
+  version: 3.1.4-1

--- a/vars/distribution_Ubuntu-22.yml
+++ b/vars/distribution_Ubuntu-22.yml
@@ -1,0 +1,3 @@
+---
+aem_dispatcher_libssl_path: /lib/x86_64-linux-gnu
+aem_dispatcher_libssl_deb_package: http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb


### PR DESCRIPTION
Ubuntu 22 ships with libssl3 so we have to install an version from the ubuntu archive instead.